### PR TITLE
Hasura parser library package location update

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ fastify.hasura.registerAction('login', async (request, reply) => {
 })
 ```
 
-_**Note:** Requests for events and actions are decorated with [hasura-parser](https://github.com/resultdoo/hasura-parser). So, you can easily retrieve data in routes with `request.event` and `request.action`._
+_**Note:** Requests for events and actions are decorated with [hasura-parser](https://github.com/snotra-org/hasura-parser). So, you can easily retrieve data in routes with `request.event` and `request.action`._
 
 ### Options
 
@@ -93,7 +93,7 @@ fastify.register(require('fastify-hasura'), {
 
 - [Hasura GraphQL Engine Documentation](https://hasura.io/docs/latest/graphql/core/index.html)
 - [graphql-request](https://www.npmjs.com/package/graphql-request)
-- [hasura-parser](https://github.com/resultdoo/hasura-parser)
+- [hasura-parser](https://github.com/snotra-org/hasura-parser)
 
 ## Contributions
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-hasura",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A fastify plugin to have fun with Hasura.",
   "main": "plugin.js",
   "type": "module",
@@ -27,7 +27,7 @@
     "node": ">=10"
   },
   "dependencies": {
-    "@result/hasura-parser": "^1.0.1",
+    "@snotra/hasura-parser": "^1.0.2",
     "fastify-plugin": "^3.0.0",
     "fastify-sensible": "^3.1.1",
     "graphql": "^15.5.0",

--- a/routes.js
+++ b/routes.js
@@ -1,4 +1,4 @@
-import { EventParser, ActionParser } from '@result/hasura-parser'
+import { EventParser, ActionParser } from '@snotra/hasura-parser'
 
 async function hasuraRoutes(fastify, options) {
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -256,10 +256,10 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@result/hasura-parser@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@result/hasura-parser/-/hasura-parser-1.0.1.tgz#38ee9f37960f4d171f9c428221fd596816c3c0e8"
-  integrity sha512-T1XaTdIutEwn9CiBf9ck5P3o+R4/BYfVwx68U2uLVosNdhnXbTYzNWDiSr54dqvRZ4ON3+YGgwCPBzmUjhDA5g==
+"@snotra/hasura-parser@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@snotra/hasura-parser/-/hasura-parser-1.0.2.tgz#a5e038e0b8d630cd1e085dbfd03fb4c622106ffa"
+  integrity sha512-ZeNmV/O27FsON4cjh/pUWhN8sTw+DVQ5rCPnOQ8sycKo07yFxgCoUSi9yZKloKM+SSWHe4IjMT7Ivft4DbnyCQ==
 
 "@types/prop-types@*":
   version "15.7.3"


### PR DESCRIPTION
### Changes proposed in this Pull Request

The Hasura Parser library has switched maintainers and also switched namespaces from `@result` to `@snotra` and the original package has been marked deprecated. 

All active work is now done in the new package namespace, therefore the library has been updated in the `package.json` file and references to the new namespace have been updated in files.

### Testing instructions

1. Should not require testing as it is merely a version bump.